### PR TITLE
change 4-point stencil to 3-point stencil for Neumann

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
@@ -240,11 +240,11 @@ struct CartesianYeeAlgorithm {
     if(ncomp != nodality){
           if ( Ms_hi_x == 0.) //non-magnetic on right
           {
-                return inv_dx*inv_dx*(2.*F(i,j,k,ncomp) - 5.*F(i-1,j,k,ncomp) + 4.*F(i-2,j,k,ncomp) - F(i-3,j,k,ncomp));
+                return inv_dx*inv_dx*(F(i,j,k,ncomp) - 2.* F(i-1,j,k,ncomp) + F(i-2,j,k,ncomp));
           }
           else if (Ms_lo_x == 0.) //non-magnetic on left
           {
-                return inv_dx*inv_dx*(2.*F(i,j,k,ncomp) - 5.*F(i+1,j,k,ncomp) + 4.*F(i+2,j,k,ncomp) - F(i+3,j,k,ncomp));
+                return inv_dx*inv_dx*(F(i,j,k,ncomp) - 2.* F(i+1,j,k,ncomp) + F(i+2,j,k,ncomp));
       } else
           {
              return inv_dx*(UpwardDx(F, coefs_x, n_coefs_x, i, j, k, ncomp) - DownwardDx(F, coefs_x, n_coefs_x, i, j, k, ncomp));
@@ -276,11 +276,11 @@ struct CartesianYeeAlgorithm {
     if(ncomp != nodality){
           if ( Ms_hi_y == 0.) //non-magnetic on right
           {
-                return inv_dy*inv_dy*(2.*F(i,j,k,ncomp) - 5.*F(i,j-1,k,ncomp) + 4.*F(i,j-2,k,ncomp) - F(i,j-3,k,ncomp));
+                return inv_dy*inv_dy*(F(i,j,k,ncomp) - 2.*F(i,j-1,k,ncomp) + F(i,j-2,k,ncomp));
           }
           else if (Ms_lo_y == 0.) //non-magnetic on left
           {
-                return inv_dy*inv_dy*(2.*F(i,j,k,ncomp) - 5.*F(i,j+1,k,ncomp) + 4.*F(i,j+2,k,ncomp) - F(i,j+3,k,ncomp));
+                return inv_dy*inv_dy*(F(i,j,k,ncomp) - 2.*F(i,j+1,k,ncomp) + F(i,j+2,k,ncomp));
       } else
           {
              return inv_dy*(UpwardDy(F, coefs_y, n_coefs_y, i, j, k, ncomp) - DownwardDy(F, coefs_y, n_coefs_y, i, j, k, ncomp));
@@ -312,11 +312,11 @@ struct CartesianYeeAlgorithm {
     if(ncomp != nodality){
           if ( Ms_hi_z == 0.) //non-magnetic on right
           {
-                return inv_dz*inv_dz*(2.*F(i,j,k,ncomp) - 5.*F(i,j,k-1,ncomp) + 4.*F(i,j,k-2,ncomp) - F(i,j,k-3,ncomp));
+                return inv_dz*inv_dz*(F(i,j,k,ncomp) - 2.*F(i,j,k-1,ncomp) + F(i,j,k-2,ncomp));
           }
           else if (Ms_lo_z == 0.) //non-magnetic on left
           {
-                return inv_dz*inv_dz*(2.*F(i,j,k,ncomp) - 5.*F(i,j,k+1,ncomp) + 4.*F(i,j,k+2,ncomp) - F(i,j,k+3,ncomp));
+                return inv_dz*inv_dz*(F(i,j,k,ncomp) - 2.*F(i,j,k+1,ncomp) + F(i,j,k+2,ncomp));
       } else
           {
              return inv_dz*(UpwardDz(F, coefs_z, n_coefs_z, i, j, k, ncomp) - DownwardDz(F, coefs_z, n_coefs_z, i, j, k, ncomp));


### PR DESCRIPTION
Using 3-point stencil in the Neumann BC solved the spatial asymmetry in our 1D toy case. 

![fixdStencil](https://user-images.githubusercontent.com/58234082/144285355-5dd68d54-5939-486b-b7d9-2451b67de44d.gif)


Input:
```
################################
####### GENERAL PARAMETERS ######
#################################
max_step = 100000
amr.n_cell = 64 64 64 # number of cells spanning the domain in each coordinate direction at level 0
amr.max_grid_size = 32 # maximum size of each AMReX box, used to decompose the domain
amr.blocking_factor = 16
geometry.coord_sys = 0

geometry.prob_lo = -10e-9 -10e-9 -10.0e-9
geometry.prob_hi =  10e-9  10e-9  10.0e-9
boundary.field_lo = periodic periodic periodic
boundary.field_hi = periodic periodic periodic
amr.max_level = 0

#################################
############ NUMERICS ###########
#################################
warpx.verbose = 1
warpx.use_filter = 0
warpx.cfl = 100
warpx.mag_time_scheme_order = 2 # default 1
warpx.mag_M_normalization = 1 # 1 is saturated
warpx.mag_LLG_coupling = 0
warpx.mag_LLG_exchange_coupling = 1

algo.em_solver_medium = macroscopic # vacuum/macroscopic
algo.macroscopic_sigma_method = laxwendroff # laxwendroff or backwardeuler

macroscopic.sigma_function(x,y,z) = "0.0"
macroscopic.epsilon_function(x,y,z) = "8.8541878128e-12"
macroscopic.mu_function(x,y,z) = "1.25663706212e-06"

my_constants.mag_lo_x = -5.e-9
my_constants.mag_hi_x = 5.e-9
my_constants.mag_lo_y = -5.e-9
my_constants.mag_hi_y = 5.e-9
my_constants.mag_lo_z = -5.e-9
my_constants.mag_hi_z = 5.e-9

#unit conversion: 1 Gauss = (1000/4pi) A/m
macroscopic.mag_Ms_init_style = "parse_mag_Ms_function" # parse or "constant"
macroscopic.mag_Ms_function(x,y,z) = "1.4e5 * (x >= mag_lo_x - 1e-12) * (x <= mag_hi_x + 1e-12) * (y >= mag_lo_y - 1e-12) * (y <= mag_hi_y + 1e-12) * (z >= mag_lo_z - 1e-12) * (z <= mag_hi_z + 1e-12)"  # in unit A/m, equal to 1750 Gauss; Ms must be nonzero for LLG

macroscopic.mag_alpha_init_style = "parse_mag_alpha_function" # parse or "constant"
macroscopic.mag_alpha_function(x,y,z) = "0.058" # * (x >= mag_lo_x - 1e-12) * (x <= mag_hi_x + 1e-12) * (y >= mag_lo_y - 1e-12) * (y <= mag_hi_y + 1e-12) * (z >= mag_lo_z - 1e-12) * (z <= mag_hi_z + 1e-12)"  # alpha is unitless, calculated from linewidth Delta_H = 40 Oersted

macroscopic.mag_gamma_init_style = "parse_mag_gamma_function" # parse or "constant"
macroscopic.mag_gamma_function(x,y,z) = "-1.759e11" # * (x >= mag_lo_x - 1e-12) * (x <= mag_hi_x + 1e-12) * (y >= mag_lo_y - 1e-12) * (y <= mag_hi_y + 1e-12) * (z >= mag_lo_z - 1e-12) * (z <= mag_hi_z + 1e-12)" # gyromagnetic ratio is constant for electrons in all materials

macroscopic.mag_exchange_init_style = "parse_mag_exchange_function" # parse or "constant"
macroscopic.mag_exchange_function(x,y,z) = "3.76e-12" # * (x >= mag_lo_x) * (x <= mag_hi_x) * (y >= mag_lo_y - 1e-12) * (y <= mag_hi_y + 1e-12) * (z >= mag_lo_z - 1e-12) * (z <= mag_hi_z + 1e-12)" # exchange coupling constanit; Must be non-zero when exchange coupling is ON

macroscopic.mag_max_iter = 100 # maximum number of M iteration in each time step
macroscopic.mag_tol = 1.e-6 # M magnitude relative error tolerance compared to previous iteration
macroscopic.mag_normalized_error = 0.1 # if M magnitude relatively changes more than this value, raise a red flag

#################################
############ FIELDS #############
#################################
warpx.E_ext_grid_init_style = parse_E_ext_grid_function
warpx.Ex_external_grid_function(x,y,z) = 0.
warpx.Ey_external_grid_function(x,y,z) = 0.
warpx.Ez_external_grid_function(x,y,z) = 0.

warpx.H_ext_grid_init_style = parse_H_ext_grid_function
warpx.Hx_external_grid_function(x,y,z)= 0.
warpx.Hy_external_grid_function(x,y,z) = 0.
warpx.Hz_external_grid_function(x,y,z) = 0.

#unit conversion: 1 Gauss = 1 Oersted = (1000/4pi) A/m
#calculation of H_bias: H_bias (oe) = frequency / 2.8e6
warpx.H_bias_ext_grid_init_style = parse_H_bias_ext_grid_function
warpx.Hx_bias_external_grid_function(x,y,z)= 0.
warpx.Hy_bias_external_grid_function(x,y,z)= "3.7e4" # in A/m, equal to 464 Oersted
#warpx.Hy_bias_external_grid_function(x,y,z)= 0. # in A/m, equal to 464 Oersted
warpx.Hz_bias_external_grid_function(x,y,z)= 0.

warpx.M_ext_grid_init_style = parse_M_ext_grid_function
warpx.Mx_external_grid_function(x,y,z)= "1.4e5 * (x >= mag_lo_x - 1e-12) * (x <= mag_hi_x + 1e-12) * (y >= mag_lo_y - 1e-12) * (y < 0.) * (z >= mag_lo_z - 1e-12) * (z <= mag_hi_z + 1e-12)"
warpx.My_external_grid_function(x,y,z) = 0.
warpx.Mz_external_grid_function(x,y,z) = "1.4e5 * (x >= mag_lo_x - 1e-12) * (x <= mag_hi_x + 1e-12) * (y >= 0.) * (y <= mag_hi_y + 1e-12) * (z >= mag_lo_z - 1e-12) * (z <= mag_hi_z + 1e-12)"

#Diagnostics
diagnostics.diags_names = plt
plt.intervals = 1000
plt.diag_type = Full
plt.fields_to_plot = Ex Ey Ez Hx Hy Hz Bx By Bz Mx_xface My_xface Mz_xface Mx_yface My_yface Mz_yface Mx_zface My_zface Mz_zface
plt.plot_raw_fields = 0
```